### PR TITLE
初期化バッチとデータ更新バッチの修正

### DIFF
--- a/chartmiru/models/company.py
+++ b/chartmiru/models/company.py
@@ -17,7 +17,7 @@ class Company(db.Model):
         self.initialized = initialized
 
     @staticmethod
-    def get_companies(initialized: bool = None) -> List:
+    def get_company(initialized: bool = None) -> List:
         query = current_session.query(Company)
         query = query.filter_by(initialized=initialized) if initialized is not None else query
         companies = query.all()

--- a/chartmiru/models/company.py
+++ b/chartmiru/models/company.py
@@ -9,14 +9,17 @@ class Company(db.Model):
     __tablename__ = "company"
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Integer)
+    initialized = db.Column(db.Integer)
 
-    def __init__(self, id, name):
+    def __init__(self, id, name, initialized):
         self.id = id
         self.name = name
+        self.initialized = initialized
 
     @staticmethod
-    def get_companies() -> List:
+    def get_companies(initialized: bool = None) -> List:
         query = current_session.query(Company)
+        query = query.filter_by(initialized=initialized) if initialized is not None else query
         companies = query.all()
         Database.flush()
         if companies is None:
@@ -25,3 +28,11 @@ class Company(db.Model):
             'id': company.id,
             'name': company.name
         }, companies))
+
+
+    @staticmethod
+    def update_company(id: int, initialized: bool = None) -> None:
+        company = current_session.query(Company).get(id)
+        company.initialized = initialized if initialized else company.initialized
+        current_session.add(company)
+        Database.commit()

--- a/chartmiru/models/stock.py
+++ b/chartmiru/models/stock.py
@@ -60,3 +60,16 @@ class Stock(db.Model):
         query = query.filter_by(company_id=company_id)
         query.delete()
         Database.commit()
+
+    @staticmethod
+    def get_stock(company_id: int, data_date: datetime = None) -> List:
+        query = current_session.query(Stock)
+        query = query.filter_by(company_id=company_id)
+        query = query.filter_by(data_date=data_date) if data_date else query
+        stocks = query.all()
+        Database.commit()
+        if stocks is None:
+            return []
+        return list(map(lambda stock: {
+            'id': stock.id,
+        }, stocks))

--- a/chartmiru/models/stock.py
+++ b/chartmiru/models/stock.py
@@ -53,3 +53,10 @@ class Stock(db.Model):
                 volume=stock['volume'])
                 for stock in stocks], return_defaults=False)
         Database.commit()
+
+    @staticmethod
+    def delete_stock(company_id: int) -> None:
+        query = current_session.query(Stock)
+        query = query.filter_by(company_id=company_id)
+        query.delete()
+        Database.commit()

--- a/chartmiru/stocks.py
+++ b/chartmiru/stocks.py
@@ -1,5 +1,6 @@
 import requests
 from typing import List, Dict
+import datetime
 
 from flask_sqlalchemy_session import current_session
 
@@ -20,3 +21,10 @@ class Stocks:
 
         except requests.exceptions.RequestException as err:
             print(err)
+
+    @classmethod
+    def exist_latest_data(cls, company_id: int, latest_data_date: datetime) -> bool:
+        stock = Stock.get_stock(company_id, latest_data_date)
+        if stock == []:
+            return False
+        return True

--- a/cli.py
+++ b/cli.py
@@ -18,6 +18,13 @@ def register_stock():
     for company in companies:
         stocks = s.get_row_stocks(company['id'], datetime.date.today().year)
         latest_data = stocks[-1]
+        '''
+        祝日にバッチが回った時はデータが被ってしまうので更新しない
+        また何らかの理由により参照元データが更新されていない場合はDBとデータが被ってしまうので更新しない
+        '''
+        if s.exist_latest_data(company['id'], latest_data['data_date']):
+            #TODO: log出力したい
+            continue
         Stock.insert_stock(
             latest_data['company_id'],
             latest_data['open'],

--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,7 @@ STOCK_DATA_INITIALIZED = True
 
 @app.cli.command('register_stock', help='各銘柄の昨日の株取得')
 def register_stock():
-    companies = Company.get_companies()
+    companies = Company.get_company(STOCK_DATA_INITIALIZED)
     s = Stocks()
     for company in companies:
         stocks = s.get_row_stocks(company['id'], datetime.date.today().year)
@@ -34,7 +34,7 @@ def register_stock():
 @click.argument('target_year', default=datetime.date.today().year)
 @click.argument('from_year', default=datetime.date.today().year)
 def register_initial_stock(target_year: int, from_year: int):
-    companies = Company.get_companies(not STOCK_DATA_INITIALIZED)
+    companies = Company.get_company(not STOCK_DATA_INITIALIZED)
     s = Stocks()
     for company in companies:
         # 初期化する時は元のデータを一度すべて消す

--- a/cli.py
+++ b/cli.py
@@ -9,6 +9,8 @@ from chartmiru.stocks import Stocks
 from chartmiru.models.stock import Stock
 from chartmiru.models.company import Company
 
+STOCK_DATA_INITIALIZED = True
+
 @app.cli.command('register_stock', help='各銘柄の昨日の株取得')
 def register_stock():
     companies = Company.get_companies()
@@ -29,14 +31,18 @@ def register_stock():
 
 
 @app.cli.command('register_initial_stock', help='各銘柄の過去の株を取得する')
-@click.argument('stock_code')
 @click.argument('target_year', default=datetime.date.today().year)
 @click.argument('from_year', default=datetime.date.today().year)
-def register_initial_stock(stock_code: int, target_year: int, from_year: int):
+def register_initial_stock(target_year: int, from_year: int):
+    companies = Company.get_companies(not STOCK_DATA_INITIALIZED)
     s = Stocks()
-    for year in range(from_year, target_year + 1):
-        stocks= s.get_row_stocks(stock_code, year)
-        Stock.bulk_insert_stocks(stocks)
+    for company in companies:
+        # 初期化する時は元のデータを一度すべて消す
+        Stock.delete_stock(company['id'])
+        for year in range(from_year, target_year + 1):
+            stocks= s.get_row_stocks(company['id'], year)
+            Stock.bulk_insert_stocks(stocks)
+            Company.update_company(company['id'], STOCK_DATA_INITIALIZED)
 
 
 #TODO:撮り損ねた株を一気に回収するバッチ


### PR DESCRIPTION
- 初期化バッチ
  - companyテーブルに入っている未初期化銘柄を抽出して、stockテーブルにそれぞれの銘柄の株データがあるないに関係なくとにかく削除し、データをstockテーブルにinsertする

- 株データ更新バッチ
  - 毎日回る想定で作っており、祝日に回った時や、何らかの理由で参照元最新データとDBの最新データがかぶった場合はデータをstockテーブルに入れないように変更